### PR TITLE
Pin 912: Persistent Volume

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,151 +56,151 @@ pipeline {
         }
         stage('Deploy Services') {
           parallel {
-            // stage('Front End') {
-            //   environment {
-            //     SERVICE_NAME = getVariableFromConf("FRONTEND_SERVICE_NAME")
-            //     IMAGE_VERSION = getVariableFromConf("FRONTEND_IMAGE_VERSION")
-            //     IMAGE_DIGEST =  getDockerImageDigest(SERVICE_NAME, IMAGE_VERSION)
-            //   }
-            //   steps {
-            //     applyKubeFile('frontend/ingress.yaml', SERVICE_NAME)
-            //     applyKubeFile('frontend/configmap.yaml', SERVICE_NAME)
-            //     applyKubeFile('frontend/deployment.yaml', SERVICE_NAME, IMAGE_DIGEST)
-            //     applyKubeFile('frontend/service.yaml', SERVICE_NAME)
-            //   }
-            // }
-            // stage('Agreement Management') {
-            //   steps {
-            //     applyKustomizeToDir(
-            //       'overlays/agreement-management', 
-            //       getVariableFromConf("AGREEMENT_MANAGEMENT_SERVICE_NAME"), 
-            //       getVariableFromConf("AGREEMENT_MANAGEMENT_IMAGE_VERSION"),
-            //       getVariableFromConf("INTERNAL_APPLICATION_HOST"),
-            //       getVariableFromConf("INTERNAL_INGRESS_CLASS")
-            //     )
-            //   }
-            // }
-            // stage('Agreement Process') {
-            //   steps {
-            //     applyKustomizeToDir(
-            //       'overlays/agreement-process', 
-            //       getVariableFromConf("AGREEMENT_PROCESS_SERVICE_NAME"),
-            //       getVariableFromConf("AGREEMENT_PROCESS_IMAGE_VERSION"),
-            //       getVariableFromConf("EXTERNAL_APPLICATION_HOST"),
-            //       getVariableFromConf("EXTERNAL_INGRESS_CLASS")
-            //     )
-            //   }
-            // }
-            // stage('Attribute Registry Management') {
-            //   steps {
-            //     applyKustomizeToDir(
-            //       'overlays/attribute-registry-management', 
-            //       getVariableFromConf("ATTRIBUTE_REGISTRY_MANAGEMENT_SERVICE_NAME"),
-            //       getVariableFromConf("ATTRIBUTE_REGISTRY_MANAGEMENT_IMAGE_VERSION"),
-            //       getVariableFromConf("INTERNAL_APPLICATION_HOST"),
-            //       getVariableFromConf("INTERNAL_INGRESS_CLASS")
-            //     )
-            //   }
-            // }
-            // stage('Authorization Management') {
-            //   steps {
-            //     applyKustomizeToDir(
-            //       'overlays/authorization-management', 
-            //       getVariableFromConf("AUTHORIZATION_MANAGEMENT_SERVICE_NAME"),
-            //       getVariableFromConf("AUTHORIZATION_MANAGEMENT_IMAGE_VERSION"),
-            //       getVariableFromConf("INTERNAL_APPLICATION_HOST"),
-            //       getVariableFromConf("INTERNAL_INGRESS_CLASS")
-            //     )
-            //   }
-            // }
-            // stage('Authorization Process') {
-            //   steps {
-            //     applyKustomizeToDir(
-            //       'overlays/authorization-process', 
-            //       getVariableFromConf("AUTHORIZATION_PROCESS_SERVICE_NAME"),
-            //       getVariableFromConf("AUTHORIZATION_PROCESS_IMAGE_VERSION"),
-            //       getVariableFromConf("EXTERNAL_APPLICATION_HOST"),
-            //       getVariableFromConf("EXTERNAL_INGRESS_CLASS")
-            //     )
-            //   }
-            // }
-            // stage('Catalog Management') {
-            //   steps {
-            //     applyKustomizeToDir(
-            //       'overlays/catalog-management', 
-            //       getVariableFromConf("CATALOG_MANAGEMENT_SERVICE_NAME"),
-            //       getVariableFromConf("CATALOG_MANAGEMENT_IMAGE_VERSION"),
-            //       getVariableFromConf("INTERNAL_APPLICATION_HOST"),
-            //       getVariableFromConf("INTERNAL_INGRESS_CLASS")
-            //     )
-            //   }
-            // }
-            // stage('Catalog Process') {
-            //   steps {
-            //     applyKustomizeToDir(
-            //       'overlays/catalog-process', 
-            //       getVariableFromConf("CATALOG_PROCESS_SERVICE_NAME"),
-            //       getVariableFromConf("CATALOG_PROCESS_IMAGE_VERSION"),
-            //       getVariableFromConf("EXTERNAL_APPLICATION_HOST"),
-            //       getVariableFromConf("EXTERNAL_INGRESS_CLASS")
-            //     )
-            //   }
-            // }
-            // stage('Party Management') {
-            //   steps {
-            //     applyKustomizeToDir(
-            //       'overlays/party-management', 
-            //       getVariableFromConf("PARTY_MANAGEMENT_SERVICE_NAME"), 
-            //       getVariableFromConf("PARTY_MANAGEMENT_IMAGE_VERSION"),
-            //       getVariableFromConf("INTERNAL_APPLICATION_HOST"),
-            //       getVariableFromConf("INTERNAL_INGRESS_CLASS")
-            //     )
-            //   }
-            // }
-            // stage('Party Mock Registry') {
-            //   steps {
-            //     applyKustomizeToDir(
-            //       'overlays/party-mock-registry', 
-            //       getVariableFromConf("PARTY_MOCK_REGISTRY_SERVICE_NAME"), 
-            //       getVariableFromConf("PARTY_MOCK_REGISTRY_IMAGE_VERSION"),
-            //       getVariableFromConf("INTERNAL_APPLICATION_HOST"),
-            //       getVariableFromConf("INTERNAL_INGRESS_CLASS")
-            //     )
-            //   }
-            // }
-            // stage('Party Process') {
-            //   steps {
-            //     applyKustomizeToDir(
-            //       'overlays/party-process', 
-            //       getVariableFromConf("PARTY_PROCESS_SERVICE_NAME"), 
-            //       getVariableFromConf("PARTY_PROCESS_IMAGE_VERSION"),
-            //       getVariableFromConf("EXTERNAL_APPLICATION_HOST"),
-            //       getVariableFromConf("EXTERNAL_INGRESS_CLASS")
-            //     )
-            //   }
-            // }
-            // stage('Party Registry Proxy') {
-            //   steps {
-            //     applyKustomizeToDir(
-            //       'overlays/party-registry-proxy', 
-            //       getVariableFromConf("PARTY_REGISTRY_PROXY_SERVICE_NAME"), 
-            //       getVariableFromConf("PARTY_REGISTRY_PROXY_IMAGE_VERSION"),
-            //       getVariableFromConf("INTERNAL_APPLICATION_HOST"),
-            //       getVariableFromConf("INTERNAL_INGRESS_CLASS")
-            //     )
-            //   }
-            // }
-            // stage('User Registry Management') {
-            //   steps {
-            //     applyKustomizeToDir(
-            //       'overlays/user-registry-management', 
-            //       getVariableFromConf("USER_REGISTRY_MANAGEMENT_SERVICE_NAME"), 
-            //       getVariableFromConf("USER_REGISTRY_MANAGEMENT_IMAGE_VERSION"),
-            //       getVariableFromConf("INTERNAL_APPLICATION_HOST"),
-            //       getVariableFromConf("INTERNAL_INGRESS_CLASS")
-            //     )
-            //   }
-            // }
+            stage('Front End') {
+              environment {
+                SERVICE_NAME = getVariableFromConf("FRONTEND_SERVICE_NAME")
+                IMAGE_VERSION = getVariableFromConf("FRONTEND_IMAGE_VERSION")
+                IMAGE_DIGEST =  getDockerImageDigest(SERVICE_NAME, IMAGE_VERSION)
+              }
+              steps {
+                applyKubeFile('frontend/ingress.yaml', SERVICE_NAME)
+                applyKubeFile('frontend/configmap.yaml', SERVICE_NAME)
+                applyKubeFile('frontend/deployment.yaml', SERVICE_NAME, IMAGE_DIGEST)
+                applyKubeFile('frontend/service.yaml', SERVICE_NAME)
+              }
+            }
+            stage('Agreement Management') {
+              steps {
+                applyKustomizeToDir(
+                  'overlays/agreement-management', 
+                  getVariableFromConf("AGREEMENT_MANAGEMENT_SERVICE_NAME"), 
+                  getVariableFromConf("AGREEMENT_MANAGEMENT_IMAGE_VERSION"),
+                  getVariableFromConf("INTERNAL_APPLICATION_HOST"),
+                  getVariableFromConf("INTERNAL_INGRESS_CLASS")
+                )
+              }
+            }
+            stage('Agreement Process') {
+              steps {
+                applyKustomizeToDir(
+                  'overlays/agreement-process', 
+                  getVariableFromConf("AGREEMENT_PROCESS_SERVICE_NAME"),
+                  getVariableFromConf("AGREEMENT_PROCESS_IMAGE_VERSION"),
+                  getVariableFromConf("EXTERNAL_APPLICATION_HOST"),
+                  getVariableFromConf("EXTERNAL_INGRESS_CLASS")
+                )
+              }
+            }
+            stage('Attribute Registry Management') {
+              steps {
+                applyKustomizeToDir(
+                  'overlays/attribute-registry-management', 
+                  getVariableFromConf("ATTRIBUTE_REGISTRY_MANAGEMENT_SERVICE_NAME"),
+                  getVariableFromConf("ATTRIBUTE_REGISTRY_MANAGEMENT_IMAGE_VERSION"),
+                  getVariableFromConf("INTERNAL_APPLICATION_HOST"),
+                  getVariableFromConf("INTERNAL_INGRESS_CLASS")
+                )
+              }
+            }
+            stage('Authorization Management') {
+              steps {
+                applyKustomizeToDir(
+                  'overlays/authorization-management', 
+                  getVariableFromConf("AUTHORIZATION_MANAGEMENT_SERVICE_NAME"),
+                  getVariableFromConf("AUTHORIZATION_MANAGEMENT_IMAGE_VERSION"),
+                  getVariableFromConf("INTERNAL_APPLICATION_HOST"),
+                  getVariableFromConf("INTERNAL_INGRESS_CLASS")
+                )
+              }
+            }
+            stage('Authorization Process') {
+              steps {
+                applyKustomizeToDir(
+                  'overlays/authorization-process', 
+                  getVariableFromConf("AUTHORIZATION_PROCESS_SERVICE_NAME"),
+                  getVariableFromConf("AUTHORIZATION_PROCESS_IMAGE_VERSION"),
+                  getVariableFromConf("EXTERNAL_APPLICATION_HOST"),
+                  getVariableFromConf("EXTERNAL_INGRESS_CLASS")
+                )
+              }
+            }
+            stage('Catalog Management') {
+              steps {
+                applyKustomizeToDir(
+                  'overlays/catalog-management', 
+                  getVariableFromConf("CATALOG_MANAGEMENT_SERVICE_NAME"),
+                  getVariableFromConf("CATALOG_MANAGEMENT_IMAGE_VERSION"),
+                  getVariableFromConf("INTERNAL_APPLICATION_HOST"),
+                  getVariableFromConf("INTERNAL_INGRESS_CLASS")
+                )
+              }
+            }
+            stage('Catalog Process') {
+              steps {
+                applyKustomizeToDir(
+                  'overlays/catalog-process', 
+                  getVariableFromConf("CATALOG_PROCESS_SERVICE_NAME"),
+                  getVariableFromConf("CATALOG_PROCESS_IMAGE_VERSION"),
+                  getVariableFromConf("EXTERNAL_APPLICATION_HOST"),
+                  getVariableFromConf("EXTERNAL_INGRESS_CLASS")
+                )
+              }
+            }
+            stage('Party Management') {
+              steps {
+                applyKustomizeToDir(
+                  'overlays/party-management', 
+                  getVariableFromConf("PARTY_MANAGEMENT_SERVICE_NAME"), 
+                  getVariableFromConf("PARTY_MANAGEMENT_IMAGE_VERSION"),
+                  getVariableFromConf("INTERNAL_APPLICATION_HOST"),
+                  getVariableFromConf("INTERNAL_INGRESS_CLASS")
+                )
+              }
+            }
+            stage('Party Mock Registry') {
+              steps {
+                applyKustomizeToDir(
+                  'overlays/party-mock-registry', 
+                  getVariableFromConf("PARTY_MOCK_REGISTRY_SERVICE_NAME"), 
+                  getVariableFromConf("PARTY_MOCK_REGISTRY_IMAGE_VERSION"),
+                  getVariableFromConf("INTERNAL_APPLICATION_HOST"),
+                  getVariableFromConf("INTERNAL_INGRESS_CLASS")
+                )
+              }
+            }
+            stage('Party Process') {
+              steps {
+                applyKustomizeToDir(
+                  'overlays/party-process', 
+                  getVariableFromConf("PARTY_PROCESS_SERVICE_NAME"), 
+                  getVariableFromConf("PARTY_PROCESS_IMAGE_VERSION"),
+                  getVariableFromConf("EXTERNAL_APPLICATION_HOST"),
+                  getVariableFromConf("EXTERNAL_INGRESS_CLASS")
+                )
+              }
+            }
+            stage('Party Registry Proxy') {
+              steps {
+                applyKustomizeToDir(
+                  'overlays/party-registry-proxy', 
+                  getVariableFromConf("PARTY_REGISTRY_PROXY_SERVICE_NAME"), 
+                  getVariableFromConf("PARTY_REGISTRY_PROXY_IMAGE_VERSION"),
+                  getVariableFromConf("INTERNAL_APPLICATION_HOST"),
+                  getVariableFromConf("INTERNAL_INGRESS_CLASS")
+                )
+              }
+            }
+            stage('User Registry Management') {
+              steps {
+                applyKustomizeToDir(
+                  'overlays/user-registry-management', 
+                  getVariableFromConf("USER_REGISTRY_MANAGEMENT_SERVICE_NAME"), 
+                  getVariableFromConf("USER_REGISTRY_MANAGEMENT_IMAGE_VERSION"),
+                  getVariableFromConf("INTERNAL_APPLICATION_HOST"),
+                  getVariableFromConf("INTERNAL_INGRESS_CLASS")
+                )
+              }
+            }
             
             stage('Spid') {
               when { 

--- a/kubernetes/spid/idp/deployment.yaml
+++ b/kubernetes/spid/idp/deployment.yaml
@@ -34,9 +34,8 @@ spec:
               mountPath: "/app/certs"
               readOnly: true
       initContainers:
-      # Volumes loaded from secrets are read only
-      # The application needs to write in the same folder
-      # This init container is used as workaround to load secrets and copy them to a new read-write volume
+        # Used to initialize users file if not already created
+        # Note: A better solution is to use dataSourceRef on pvc, but it is available on k8s 1.22+
         - name: rw-conf-directory
           image: busybox:1.34
           command: ['sh', '-c', "cp -n /temp/app/conf/users.json /app/conf/users.json"]
@@ -48,21 +47,17 @@ spec:
               mountPath: "/app/conf"
       volumes:
         - name: config
-          projected:
-            sources:
-              - configMap:
-                  name: {{SERVICE_NAME}}
-                  items:
-                    - key: config.yaml
-                      path: config.yaml
+          configMap:
+            name: {{SERVICE_NAME}}
+            items:
+              - key: config.yaml
+                path: config.yaml
         - name: users-tmp
-          projected:
-            sources:
-              - configMap:
-                  name: {{SERVICE_NAME}}
-                  items:
-                    - key: users.json
-                      path: users.json
+          configMap:
+            name: {{SERVICE_NAME}}
+            items:
+              - key: users.json
+                path: users.json
         - name: users
           persistentVolumeClaim:
             claimName: {{SERVICE_NAME}}-users

--- a/kubernetes/spid/idp/pvc.yaml
+++ b/kubernetes/spid/idp/pvc.yaml
@@ -10,5 +10,5 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 50Mi
+      storage: 100Mi
   volumeMode: Filesystem


### PR DESCRIPTION
This PR adds a Persistent Volume (PV) to the Identity Provider pod.

### Reason
Users file was stored in the IdP pod local volume, this means that on pod restart all users created using the UI would have been lost.

### Solution
Now users file is stored in a PV that will survive to pod restart.

### Details
One PV is created per namespace.
The creation of a PV in k8s creates an EBS volume on AWS.
The PV and the EBS volume are deleted on namespace deletion.
The minimum provisionable size of an EBS is 1GB.

### Costs
Roughly, keeping 20 EBS (so 20 namespaces) a whole months in the current AWS region would cost ~ $1.08/month
Reference https://aws.amazon.com/ebs/pricing/