### PR TITLE
PIN-1938: Updated and activated Content Security Policy (CSP)

### DIFF
--- a/kubernetes/frontend/configmap.yaml
+++ b/kubernetes/frontend/configmap.yaml
@@ -16,7 +16,7 @@ data:
             sub_filter_once off;
             sub_filter_types *;
             sub_filter **CSP_NONCE** $request_id;
-            add_header Content-Security-Policy-Report-Only "default-src 'self'; object-src 'none'; connect-src 'self' https://api-eu.mixpanel.com/track/ {{PUBLIC_BUCKET_URL}}; script-src 'self' 'nonce-$request_id'; style-src 'self' 'unsafe-inline'; worker-src 'none'; font-src 'self'; img-src 'self' data:";
+            add_header Content-Security-Policy "default-src 'self'; object-src 'none'; connect-src 'self' {{PUBLIC_BUCKET_URL}}; script-src 'nonce-$request_id'; style-src 'self' 'unsafe-inline'; worker-src 'none'; font-src 'self'; img-src 'self' data:; base-uri 'self'";
             add_header Strict-Transport-Security "max-age=31536000";
             add_header X-Content-Type-Options "nosniff";
             add_header X-Frame-Options "SAMEORIGIN";


### PR DESCRIPTION
CSP was only in "Report mode", now it is fully active. Three changes were made:
- MixPanel script was removed as it is not used now
- script can only be loaded with a nonce applied
- base-uri now should correspond to the same domain