### PR TITLE
Add 'app' label to cronjob pods

### DIFF
--- a/kubernetes/jobs/attributes-loader/cronjob.yaml
+++ b/kubernetes/jobs/attributes-loader/cronjob.yaml
@@ -17,6 +17,9 @@ spec:
         digest: {{IMAGE_DIGEST}} # Used to force deployment on same image version but different content
     spec:
       template:
+        metadata:
+          labels:
+            app: {{SERVICE_NAME}}
         spec:
           restartPolicy: OnFailure
           serviceAccountName: {{SERVICE_NAME}}

--- a/kubernetes/jobs/tenants-certified-attributes-updater/cronjob.yaml
+++ b/kubernetes/jobs/tenants-certified-attributes-updater/cronjob.yaml
@@ -17,6 +17,9 @@ spec:
         digest: {{IMAGE_DIGEST}} # Used to force deployment on same image version but different content
     spec:
       template:
+        metadata:
+          labels:
+            app: {{SERVICE_NAME}}
         spec:
           restartPolicy: OnFailure
           serviceAccountName: {{SERVICE_NAME}}

--- a/kubernetes/jobs/token-details-persister/cronjob.yaml
+++ b/kubernetes/jobs/token-details-persister/cronjob.yaml
@@ -17,6 +17,9 @@ spec:
         digest: {{IMAGE_DIGEST}} # Used to force deployment on same image version but different content
     spec:
       template:
+        metadata:
+          labels:
+            app: {{SERVICE_NAME}}
         spec:
           restartPolicy: OnFailure
           serviceAccountName: {{SERVICE_NAME}}


### PR DESCRIPTION
Needed by the cluster log processor to route the cronjob's logs correctly