### PR TITLE
pin-2981: Adjust jobs schedule and add log to party-registry-proxy-refresher

### DIFF
--- a/kubernetes/jobs/attributes-loader/cronjob.yaml
+++ b/kubernetes/jobs/attributes-loader/cronjob.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{SERVICE_NAME}}
   namespace: {{NAMESPACE}}
 spec:
-  schedule: "0 6 * * *"
+  schedule: "15 6 * * *"
   failedJobsHistoryLimit: 1
   successfulJobsHistoryLimit: 0
   jobTemplate:

--- a/kubernetes/jobs/tenants-certified-attributes-updater/cronjob.yaml
+++ b/kubernetes/jobs/tenants-certified-attributes-updater/cronjob.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{SERVICE_NAME}}
   namespace: {{NAMESPACE}}
 spec:
-  schedule: "0 6 * * *"
+  schedule: "30 6 * * *"
   failedJobsHistoryLimit: 1
   successfulJobsHistoryLimit: 0
   jobTemplate:

--- a/kubernetes/thirdparty/party-registry-proxy-refresher/cronjob.yaml
+++ b/kubernetes/thirdparty/party-registry-proxy-refresher/cronjob.yaml
@@ -27,9 +27,7 @@ spec:
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
-              args:
-                - "-c"
-                - "'echo \"Job Started\" && ./entrypoint.sh -X POST -sS $(PARTY_REGISTRY_PROXY_URL)/reload && echo \"Job Completed\"'"
+              args: ["-c", "echo \"Job Started\" && ./entrypoint.sh -X POST -sS $(PARTY_REGISTRY_PROXY_URL)/reload && echo \"Job Completed\""]
               env:
                 - name: NAMESPACE
                   valueFrom:

--- a/kubernetes/thirdparty/party-registry-proxy-refresher/cronjob.yaml
+++ b/kubernetes/thirdparty/party-registry-proxy-refresher/cronjob.yaml
@@ -25,7 +25,11 @@ spec:
             - name: {{SERVICE_NAME}}
               image: curlimages/curl:7.88.1
               imagePullPolicy: IfNotPresent
-              args: ["-X", "POST", "$(PARTY_REGISTRY_PROXY_URL)/reload"]
+              command:
+                - /bin/sh
+              args:
+                - "-c"
+                - "'echo \"Job Started\" && ./entrypoint.sh -X POST -sS $(PARTY_REGISTRY_PROXY_URL)/reload && echo \"Job Completed\"'"
               env:
                 - name: NAMESPACE
                   valueFrom:


### PR DESCRIPTION
The jobs usually takes less than 30 seconds to run, so I scheduled them with a 15 minutes delay, but let me know if you have any consideration.

Note:`tenants-certified-attributes-updater` can take 5 minutes to run, but it is the last in the chain