### PR TITLE
fix third party job dependency in platform deployment

### DIFF
--- a/.github/workflows/platform-deployment.yaml
+++ b/.github/workflows/platform-deployment.yaml
@@ -446,7 +446,7 @@ jobs:
       deploy_purpose_process, deploy_tenant_management, deploy_tenant_process,
       deploy_backend_for_frontend, deploy_api_gateway, deploy_authorization_server,
       deploy_notifier, deploy_attributes_loader, deploy_token_details_persister,
-      deploy_tenants_certified_attributes_updater, deploy_metrics_report_generator,
+      deploy_tenants_certified_attributes_updater, deploy_party_registry_proxy_refresher, deploy_metrics_report_generator,
       deploy_padigitale_report_generator, deploy_dashboard_metrics_report_generator, deploy_redis]
     permissions:
       contents: read


### PR DESCRIPTION
Not strictly necessary, but just for consistency