### PR TITLE
feat: ingress host routing

### DIFF
--- a/.github/workflows/deploy-ingress.yaml
+++ b/.github/workflows/deploy-ingress.yaml
@@ -47,7 +47,15 @@ jobs:
           set -eo pipefail
           source $CONFIG_FILE
           source ./deployment_functions.sh
-          
+
+          if [[ ${{ inputs.environment }} = "prod" ]]; then
+            export INGRESS_RULES_HOST="*.interop.pagopa.it"
+          elif [[ ${{ inputs.environment }} = "dev-refactor" ]]; then
+            export INGRESS_RULES_HOST="*.refactor.dev.interop.pagopa.it"
+          else
+            export INGRESS_RULES_HOST="*.${{ inputs.environment }}.interop.pagopa.it"
+          fi
+
           createIngress \
               $API_GATEWAY_SERVICE_NAME $API_GATEWAY_APPLICATION_PATH $BACKEND_SERVICE_PORT \
               $AUTHORIZATION_SERVER_SERVICE_NAME $AUTHORIZATION_SERVER_APPLICATION_PATH $BACKEND_SERVICE_PORT \

--- a/.github/workflows/deploy-ingress.yaml
+++ b/.github/workflows/deploy-ingress.yaml
@@ -48,12 +48,10 @@ jobs:
           source $CONFIG_FILE
           source ./deployment_functions.sh
 
-          if [[ ${{ inputs.environment }} = "prod" ]]; then
-            export INGRESS_RULES_HOST="*.interop.pagopa.it"
-          elif [[ ${{ inputs.environment }} = "dev-refactor" ]]; then
+          if [[ ${{ inputs.environment }} = "dev-refactor" ]]; then
             export INGRESS_RULES_HOST="*.refactor.dev.interop.pagopa.it"
-          else
-            export INGRESS_RULES_HOST="*.${{ inputs.environment }}.interop.pagopa.it"
+          elif [[ ${{ inputs.environment }} = "dev" ]]; then
+            export INGRESS_RULES_HOST="*.dev.interop.pagopa.it"
           fi
 
           createIngress \

--- a/.github/workflows/deploy-ingress.yaml
+++ b/.github/workflows/deploy-ingress.yaml
@@ -50,8 +50,10 @@ jobs:
 
           if [[ ${{ inputs.environment }} = "dev-refactor" ]]; then
             export INGRESS_RULES_HOST="*.refactor.dev.interop.pagopa.it"
+            export INGRESS_RULES_ORDER=0
           elif [[ ${{ inputs.environment }} = "dev" ]]; then
             export INGRESS_RULES_HOST="*.dev.interop.pagopa.it"
+            export INGRESS_RULES_ORDER=1
           fi
 
           createIngress \

--- a/deployment_functions.sh
+++ b/deployment_functions.sh
@@ -238,7 +238,7 @@ function createIngress() {
   local compiledFileName='./kubernetes/compiled.ingress.yaml'
 
   local baseCommand="kubectl -n $NAMESPACE create ingress interop-services --class=alb --dry-run=client -o yaml "
-  local annotations=$(cat <<EOT
+  local annotations=$(cat <<EOT | tr -s '\n' ' '
   --annotation="alb.ingress.kubernetes.io/scheme=internal"
   --annotation="alb.ingress.kubernetes.io/target-type=ip"
   --annotation="alb.ingress.kubernetes.io/group.name=interop-be"
@@ -247,8 +247,6 @@ EOT
 )
 
   local rules=''
-
-  echo "INGRESS_RULES_HOST=$INGRESS_RULES_HOST"
 
   for (( j=0; j<length; j=j+3 )); do
     local i=$j

--- a/deployment_functions.sh
+++ b/deployment_functions.sh
@@ -250,7 +250,7 @@ function createIngress() {
     local applicationPath="${tuples[$k]}"
     local servicePort="${tuples[$z]}"
 
-    newRule=' --rule="/'${applicationPath}'*='${serviceName}':'${servicePort}'" '
+    newRule=' --rule="${INGRESS_RULES_HOST:+"$INGRESS_RULES_HOST"}/'${applicationPath}'*='${serviceName}':'${servicePort}'" '
     echo "Adding rule: $newRule"
     rules=$rules''$newRule
   done

--- a/deployment_functions.sh
+++ b/deployment_functions.sh
@@ -238,7 +238,13 @@ function createIngress() {
   local compiledFileName='./kubernetes/compiled.ingress.yaml'
 
   local baseCommand="kubectl -n $NAMESPACE create ingress interop-services --class=alb --dry-run=client -o yaml "
-  local annotations='--annotation="alb.ingress.kubernetes.io/scheme=internal" --annotation="alb.ingress.kubernetes.io/target-type=ip" --annotation="alb.ingress.kubernetes.io/group.name=interop-be"'
+  local annotations=$(cat <<EOT
+  --annotation="alb.ingress.kubernetes.io/scheme=internal"
+  --annotation="alb.ingress.kubernetes.io/target-type=ip"
+  --annotation="alb.ingress.kubernetes.io/group.name=interop-be"
+  --annotation="alb.ingress.kubernetes.io/load-balancer-attributes: routing.http.preserve_host_header.enabled=true"
+EOT
+)
 
   local rules=''
 

--- a/deployment_functions.sh
+++ b/deployment_functions.sh
@@ -248,6 +248,8 @@ EOT
 
   local rules=''
 
+  echo "INGRESS_RULES_HOST=$INGRESS_RULES_HOST"
+
   for (( j=0; j<length; j=j+3 )); do
     local i=$j
     local k=$((j+1))
@@ -256,7 +258,7 @@ EOT
     local applicationPath="${tuples[$k]}"
     local servicePort="${tuples[$z]}"
 
-    newRule=' --rule="'${INGRESS_RULES_HOST:+"$INGRESS_RULES_HOST"}'/'${applicationPath}'*='${serviceName}':'${servicePort}'" '
+    newRule=' --rule="'${INGRESS_RULES_HOST:-""}'/'${applicationPath}'*='${serviceName}':'${servicePort}'" '
     echo "Adding rule: $newRule"
     rules=$rules''$newRule
   done

--- a/deployment_functions.sh
+++ b/deployment_functions.sh
@@ -258,6 +258,9 @@ function createIngress() {
   --annotation="alb.ingress.kubernetes.io/load-balancer-attributes=routing.http.preserve_host_header.enabled=true"
 EOT
 )
+  if [[ ! -z $INGRESS_RULES_ORDER ]]; then
+    annotations="$annotations --annotation alb.ingress.kubernetes.io/group.order=$INGRESS_RULES_ORDER"
+  fi
 
   local rules=''
 

--- a/deployment_functions.sh
+++ b/deployment_functions.sh
@@ -256,7 +256,7 @@ EOT
     local applicationPath="${tuples[$k]}"
     local servicePort="${tuples[$z]}"
 
-    newRule=' --rule="${INGRESS_RULES_HOST:+"$INGRESS_RULES_HOST"}/'${applicationPath}'*='${serviceName}':'${servicePort}'" '
+    newRule=' --rule="'${INGRESS_RULES_HOST:+"$INGRESS_RULES_HOST"}'/'${applicationPath}'*='${serviceName}':'${servicePort}'" '
     echo "Adding rule: $newRule"
     rules=$rules''$newRule
   done

--- a/deployment_functions.sh
+++ b/deployment_functions.sh
@@ -242,7 +242,7 @@ function createIngress() {
   --annotation="alb.ingress.kubernetes.io/scheme=internal"
   --annotation="alb.ingress.kubernetes.io/target-type=ip"
   --annotation="alb.ingress.kubernetes.io/group.name=interop-be"
-  --annotation="alb.ingress.kubernetes.io/load-balancer-attributes: routing.http.preserve_host_header.enabled=true"
+  --annotation="alb.ingress.kubernetes.io/load-balancer-attributes=routing.http.preserve_host_header.enabled=true"
 EOT
 )
 


### PR DESCRIPTION
Create host-based ingress rules for dev and dev-refactor environment.
This allows a single instance of VPC Link, NLB, ALB to handle requests for both namespaces without collisions.