### PR TITLE
Update DEV CSP with OneTrust

### DIFF
--- a/kubernetes/frontend/dev/configmap.yaml
+++ b/kubernetes/frontend/dev/configmap.yaml
@@ -16,7 +16,7 @@ data:
             sub_filter_once off;
             sub_filter_types *;
             sub_filter **CSP_NONCE** $request_id;
-            add_header Content-Security-Policy "default-src 'self'; object-src 'none'; connect-src 'self' https://api-eu.mixpanel.com {{PUBLIC_BUCKET_URL}}; script-src 'nonce-$request_id'; style-src 'self' 'unsafe-inline'; worker-src 'none'; font-src 'self'; img-src 'self' {{PUBLIC_BUCKET_URL}} data:; base-uri 'self'";
+            add_header Content-Security-Policy "default-src 'self'; object-src 'none'; connect-src 'self' https://api-eu.mixpanel.com https://privacyportal-de.onetrust.com {{PUBLIC_BUCKET_URL}}; script-src 'nonce-$request_id'; style-src 'self' 'unsafe-inline'; worker-src 'none'; font-src 'self'; img-src 'self' {{PUBLIC_BUCKET_URL}} data:; base-uri 'self'";
             add_header Strict-Transport-Security "max-age=31536000";
             add_header X-Content-Type-Options "nosniff";
             add_header X-Frame-Options "SAMEORIGIN";


### PR DESCRIPTION
This is the continuation of #480. We also need to add the URL for OneTrust to be able to send the user preference remotely to the OneTrust DB. OneTrust does not have a specific path for the API, so we need to authorize the whole domain (emoji che si scioglie)